### PR TITLE
Use latest Hugo version

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,6 @@
       <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
       <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">
       <link rel="icon" href="{{ .Site.BaseURL }}favicon.ico">
-      {{ .Hugo.Generator }}
       <title>{{ .Site.Title }}</title>
       <link rel="canonical" href="{{ .Permalink}}" />
       <link href='https://fonts.googleapis.com/css?family=Lato:300,700|Roboto:100,300,500' rel='stylesheet' type='text/css'>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "hugo"
+  publish = "public"
+
+[build.environment]
+  HUGO_VERSION = "0.111.3"


### PR DESCRIPTION
I updated this site to use the latest Hugo version for Netlify builds, which now automatically generates the `<meta name="generator">` tag. So there’s no need to include it manually anymore.